### PR TITLE
Fixes script tag when defer = false

### DIFF
--- a/src/View/Helper/AssetMixHelper.php
+++ b/src/View/Helper/AssetMixHelper.php
@@ -53,7 +53,8 @@ class AssetMixHelper extends Helper
      */
     public function script(string $url, array $options = []): ?string
     {
-        $options = array_merge($options, ['defer' => true]);
+        $defaults = ['defer' => true];
+        $options += $defaults;
 
         // Get css file path, add extension if not provided, skip if url provided
         if (strpos($url, '//') !== false) {

--- a/tests/TestCase/View/Helper/AssetMixHelperTest.php
+++ b/tests/TestCase/View/Helper/AssetMixHelperTest.php
@@ -173,4 +173,21 @@ class AssetMixHelperTest extends TestCase
         $this->assertStringContainsString('/js/app.js?id=f059fcadc7eba26be9ae', $result);
         $this->assertStringContainsString('defer="defer"', $result);
     }
+
+    /**
+     * Test `script()` function returns proper tag
+     * without defer option
+     *
+     * @return void
+     */
+    public function testScriptTagWithoutDefer()
+    {
+        $this->_copyWithVersion();
+
+        $result = $this->AssetMix->script('app', ['defer' => false]);
+
+        $this->assertStringContainsString('<script', $result);
+        $this->assertStringContainsString('/js/app.js?id=f059fcadc7eba26be9ae', $result);
+        $this->assertStringNotContainsString('defer', $result);
+    }
 }


### PR DESCRIPTION
When `$this->AssetMix->script('app', ['defer' => false])` is called, the output script tag still contains the defer="defer" option. I fixed it by changing the way that the default options are merged.