### PR TITLE
Changes the $helpers access modifier

### DIFF
--- a/src/View/Helper/AssetMixHelper.php
+++ b/src/View/Helper/AssetMixHelper.php
@@ -17,7 +17,7 @@ class AssetMixHelper extends Helper
      *
      * @var array<string>
      */
-    protected $helpers = ['Html', 'Url'];
+    public $helpers = ['Html', 'Url'];
 
     /**
      * Creates a link element for CSS stylesheets with versioned asset.


### PR DESCRIPTION
The $helpers array should be public and not protected, as per the CakePHP's official docs:
https://book.cakephp.org/3/en/views/helpers.html#including-other-helpers