### PR TITLE
Make AssetMix /subdir aware, Remove test deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ bin/cake asset_mix generate inertia-react
 ```bash
 bin/cake asset_mix generate react --dir=resources
 ```
+## Serving CakePHP out of a Subdirectory
+Please see [docs/ServingFromSubdirectory](docs/ServingFromSudirectory.md)
+
 
 ## Version map
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,12 +1,13 @@
 <?php
 
-    use Cake\Routing\Route\DashedRoute;
-    use Cake\Routing\RouteBuilder;
+use Cake\Routing\Route\DashedRoute;
+use Cake\Routing\RouteBuilder;
 
-    /** @var RouteBuilder $routes */
-    $routes->plugin(
-        'AssetMix',
-        ['path' => '/asset-mix'],
-        function (RouteBuilder $routes) {
-            $routes->fallbacks(DashedRoute::class);
-        });
+/** @var \Cake\Routing\RouteBuilder $routes */
+$routes->plugin(
+    'AssetMix',
+    ['path' => '/asset-mix'],
+    function (RouteBuilder $routes) {
+        $routes->fallbacks(DashedRoute::class);
+    }
+);

--- a/docs/ServingFromSudirectory.md
+++ b/docs/ServingFromSudirectory.md
@@ -1,0 +1,26 @@
+# Using AssetMix Plugin when Serving CakePHP from a Subdirectory
+
+To use the AssetMixHelper methods `$this->AssetMix->css('main)` and `$this->AssetMix->script('app')` when CakePHP is being served out of a subdirectory. For example you access your CakePHP application from https://example.com/subdir and NOT https://example.com/
+
+Configure `App.base` with `/subdir`:
+
+```php
+    // config/app.php
+   'App' => [
+        'namespace' => 'App',
+        'encoding' => env('APP_ENCODING', 'UTF-8'),
+        'defaultLocale' => env('APP_DEFAULT_LOCALE', 'en_AU'),
+        'defaultTimezone' => 'Australia/Melbourne',
+        // comment or remove the default
+        // 'base' => false,
+        // hard coded
+        'base' => '/subdir',
+        // or pull from the environment to make it portable
+        // 'base' => env('SUBDIR', false),
+        'language' => 'en',
+        'dir' => 'src',
+        'webroot' => 'webroot',
+        'wwwRoot' => WWW_ROOT,
+        //... 
+   ]
+```

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,14 +17,9 @@
         </testsuite>
     </testsuites>
 
-    <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener class="\Cake\TestSuite\Fixture\FixtureInjector">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager"/>
-            </arguments>
-        </listener>
-    </listeners>
+    <extensions>
+        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+    </extensions>
 
     <filter>
         <whitelist>

--- a/src/Mix.php
+++ b/src/Mix.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace AssetMix;
 
+use Cake\Core\Configure;
 use Exception;
 
 /**
@@ -35,11 +36,22 @@ class Mix
             $path = $matches[2];
         }
 
-        if (! starts_with($path, '/')) {
+        // strip subdir if exists
+        $subdir = Configure::read('App.base');
+
+        if ($subdir) {
+            $path = preg_replace(sprintf('+^%s+', $subdir), '', $path);
+        }
+
+        // strip asset timestamp query string
+        // /js/app.js?1674622148 becomes /js/app.js
+        $path = preg_replace('/\?.*/', '', $path);
+
+        if (!starts_with($path, '/')) {
             $path = "/{$path}";
         }
 
-        if ($manifestDirectory && ! starts_with($manifestDirectory, '/')) {
+        if ($manifestDirectory && !starts_with($manifestDirectory, '/')) {
             $manifestDirectory = "/{$manifestDirectory}";
         }
 
@@ -59,8 +71,8 @@ class Mix
         }
 
         $manifestPath = WWW_ROOT . $manifestDirectory . '/mix-manifest.json';
-        if (! isset(self::$manifests[$manifestPath])) {
-            if (! file_exists($manifestPath)) {
+        if (!isset(self::$manifests[$manifestPath])) {
+            if (!file_exists($manifestPath)) {
                 throw new Exception('The Mix manifest does not exist.');
             }
 
@@ -74,7 +86,8 @@ class Mix
         }
 
         $manifest = self::$manifests[$manifestPath];
-        if (! isset($manifest[$path])) {
+
+        if (!isset($manifest[$path])) {
             throw new Exception("Unable to locate AssetMix file: {$path}.");
         }
 

--- a/stubs/bootstrap/assets/js/app.js
+++ b/stubs/bootstrap/assets/js/app.js
@@ -4,7 +4,8 @@ try {
     window.$ = window.jQuery = require('jquery');
 
     require('bootstrap');
-} catch (e) {}
+} catch (e) {
+}
 
 /**
  * Set CSRF token as a header based on the value of the "XSRF" token cookie.

--- a/stubs/inertia-react/assets/js/Pages/Pages/Display.js
+++ b/stubs/inertia-react/assets/js/Pages/Pages/Display.js
@@ -5,5 +5,5 @@ import React from 'react';
  * when your application has been setup with inertiajs.
  */
 export default function Display() {
-    return <div>Hello world!</div>;
+    return <div> Hello world! </div>;
 }

--- a/stubs/react/assets/js/app.js
+++ b/stubs/react/assets/js/app.js
@@ -4,7 +4,8 @@ try {
     window.$ = window.jQuery = require('jquery');
 
     require('bootstrap');
-} catch (e) {}
+} catch (e) {
+}
 
 /**
  * Set CSRF token as a header based on the value of the "XSRF" token cookie.

--- a/stubs/vue/assets/js/app.js
+++ b/stubs/vue/assets/js/app.js
@@ -9,5 +9,5 @@ window.Vue = Vue;
 Vue.component('app-greet', AppGreet);
 
 const app = new Vue({
-  el: '#app'
+    el: '#app'
 });

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -6,6 +6,6 @@ use Cake\Routing\Router;
 
 Router::reload();
 
-Router::scope('/', function (RouteBuilder $routes) {
+$routes->scope('/', function (RouteBuilder $routes) {
     $routes->fallbacks(DashedRoute::class);
 });


### PR DESCRIPTION
Hi Ishan,

This patch is for when CakePHP is served out of a subdirectory and helps Mix.php to properly resolve the path to the app.css and app.js files.

I have also done some tweaks to remove the deprecation warnings when running `vendor/bin/phpunit`


Also, fixes https://github.com/ishanvyas22/asset-mix/issues/39
